### PR TITLE
GUIにファイルリロードボタンを追加

### DIFF
--- a/src/resources/reload.svg
+++ b/src/resources/reload.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <g fill="none" stroke="#ffffff" stroke-width="4" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M16 18a20 20 0 0 1 32 0l5-5v18H35l7-7A12 12 0 1 0 20 32" />
+    <path d="M48 46a20 20 0 0 1-32 0l-5 5V33h18l-7 7a12 12 0 1 0 22 0" />
+  </g>
+</svg>

--- a/src/window/main/ui_settings.py
+++ b/src/window/main/ui_settings.py
@@ -56,14 +56,18 @@ class Ui_MainWindow(object):
         
         self.open_button = SvgButton('resources/open_file.svg', MainWindow)
         self.open_button.resize(0.12)
-        self.reload_button = SvgButton('resources/play.svg', MainWindow)
-        self.reload_button.resize(0.3)
+        self.file_reload_button = SvgButton('resources/reload.svg', MainWindow)
+        self.file_reload_button.resize(0.6)
+        self.run_button = SvgButton('resources/play.svg', MainWindow)
+        self.run_button.resize(0.3)
         if platform.system() == "Darwin":
             self.open_button.setGeometry(18, 10, 60, 50)
-            self.reload_button.setGeometry(78, 10, 60, 50)
+            self.file_reload_button.setGeometry(78, 10, 60, 50)
+            self.run_button.setGeometry(138, 10, 60, 50)
         else:
             self.open_button.setGeometry(18, 30, 60, 50)
-            self.reload_button.setGeometry(78, 30, 60, 50)
+            self.file_reload_button.setGeometry(78, 30, 60, 50)
+            self.run_button.setGeometry(138, 30, 60, 50)
 
 
         self.retranslateUi(MainWindow)
@@ -194,7 +198,8 @@ class Ui_MainWindow(object):
     
     def signal_connecter(self, MainWindow):
         self.open_button.pressed.connect(MainWindow.file_open)
-        self.reload_button.pressed.connect(MainWindow.run)
+        self.file_reload_button.pressed.connect(MainWindow.file_reload)
+        self.run_button.pressed.connect(MainWindow.run)
         self.machine_settings_button.pressed.connect(MainWindow.open_machine_settings_window)
         
         self.gcode_export_button.pressed.connect(MainWindow.render_execution_result)
@@ -212,4 +217,3 @@ class Ui_MainWindow(object):
             n = int(self.editor.document().lineCount())
             self.line_number_widget.changeLineCount(n)
         
-

--- a/src/window/main/ui_settings.py
+++ b/src/window/main/ui_settings.py
@@ -57,9 +57,9 @@ class Ui_MainWindow(object):
         self.open_button = SvgButton('resources/open_file.svg', MainWindow)
         self.open_button.resize(0.12)
         self.file_reload_button = SvgButton('resources/reload.svg', MainWindow)
-        self.file_reload_button.resize(0.6)
+        self.file_reload_button.resize(0.6) # ユーザーによる手動サイズ調整
         self.run_button = SvgButton('resources/play.svg', MainWindow)
-        self.run_button.resize(0.3)
+        self.run_button.resize(0.3) # ユーザーによる手動サイズ調整
         if platform.system() == "Darwin":
             self.open_button.setGeometry(18, 10, 60, 50)
             self.file_reload_button.setGeometry(78, 10, 60, 50)

--- a/src/window/main_window.py
+++ b/src/window/main_window.py
@@ -16,7 +16,6 @@ from window.gcode_export_window     import GcodeExportWindow
 from window.machine_settings_window import MachineSettingsDialog
 from window.app_settings_window     import SettingsWindow
 from window.main.file_operations    import FileOperation
-from window.button.svg_button       import SvgButton
 
 
 
@@ -28,7 +27,6 @@ class MainWindow(QMainWindow, Ui_MainWindow):
     def __init__(self, parent=None):
         super(MainWindow, self).__init__(parent)
         self.setupUi(self)
-        self._setup_file_reload_button()
         self.new()
         grid_draw(self.graphicsView)
         self.file_operation = FileOperation()
@@ -160,22 +158,6 @@ class MainWindow(QMainWindow, Ui_MainWindow):
 
     def file_save_as(self):
         self.file_operation.save_as(self)
-
-    def _setup_file_reload_button(self):
-        self.run_button = self.reload_button
-        open_geom = self.open_button.geometry()
-        run_geom = self.run_button.geometry()
-        spacing = run_geom.x() - open_geom.x()
-        if spacing <= 0:
-            spacing = run_geom.width()
-
-        self.file_reload_button = SvgButton('resources/reload.svg', self)
-        self.file_reload_button.resize(0.12)
-        self.file_reload_button.setGeometry(run_geom)
-        self.file_reload_button.pressed.connect(self.file_reload)
-
-        new_run_x = run_geom.x() + spacing
-        self.run_button.setGeometry(new_run_x, run_geom.y(), run_geom.width(), run_geom.height())
 
     def file_reload(self):
         if not self.path:


### PR DESCRIPTION
## 概要
- エディタの内容をディスクから再読込する file_reload を実装
- ui_settings.py 上でオープン/リロード/実行ボタンを配置し、同一フローで描画
- ファイルリロード用のSVGアイコンを追加\n\n## 動作確認\n- GUI変更のみのため未実施